### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,35 @@
+name: CI
+on: [pull_request]
+
+jobs:
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo clippy --all-features
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt --check
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --all-features
+  miri:
+    name: cargo miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - run: cargo miri test --all-features
+      

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,9 @@ macro_rules! ne_vec {
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+
     #[cfg(feature = "serde")]
     #[test]
     fn it_works() {


### PR DESCRIPTION
*Add CI checks to make sure that any new pull requests aren't broken.
*Apparently the unit tests for `serde` never even passed. Now, we can avoid something like that happening again.